### PR TITLE
Improve docs for --json_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- improved description for --json_config option
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -9,17 +9,16 @@
 #      @event['action'] - Property to figure out the event type i.e. whether it is create or resolve.
 #      @event['check'] - Map of attributes from the check config which is calling this handler
 #      @event['client'] - Map of attributes from the client config for the clients from which this event is generated.
-#   option: json_config - By default, assumes the hipchat config parameters are in a file called "hipchat.json" with
-#                         "hipchat" being the top-level key of the json. This command line option allows to specify
-#                         a custom file instead of "hipchat.json" to fetch the hipchat config from.
+#   option: json_config - By default, assumes the hipchat config parameters are in the “hipchat” top-level json key.
+#                         This command line option allows to specify a custom json key.
 #
 # Output:
 #    Green coloured notification on the Hipchat room if a resolve event is seen.
 #    Yellow coloured notification used to notify warning if a create event is seen with a status of 1
 #    Red coloured notification used to notify critical if a create event is seen with a status other than 1
 #
-# Note: The default hipchat config is fetched from the predefined json config file which is "hipchat.json" or any other
-#       file defiend using the "json_config" command line option. The hipchat room could also be configured on a per client basis
+# Note: The handler config is fetched and merged from all json config files. The “hipchat” json key is used by default which can
+#       be overridden with the "json_config" command line option. The hipchat room could also be configured on a per client basis
 #       by defining the "hipchat_room" attribute in the client config file. This will override the default hipchat room where the
 #       alerts are being routed to for that particular client.
 
@@ -29,9 +28,9 @@ require 'timeout'
 
 class HipChatNotif < Sensu::Handler
   option :json_config,
-         description: 'Config Name',
-         short: '-j JsonConfig',
-         long: '--json_config JsonConfig',
+         description: 'JSON config key name',
+         short: '-j JsonKeyName',
+         long: '--json_config JsonKeyName',
          required: false
          default: 'hipchat'
 

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -33,13 +33,14 @@ class HipChatNotif < Sensu::Handler
          short: '-j JsonConfig',
          long: '--json_config JsonConfig',
          required: false
+         default: 'hipchat'
 
   def event_name
     @event['client']['name'] + '/' + @event['check']['name']
   end
 
   def handle
-    json_config = config[:json_config] || 'hipchat'
+    json_config = config[:json_config]
     server_url = settings[json_config]['server_url'] || 'https://api.hipchat.com'
     apiversion = settings[json_config]['apiversion'] || 'v1'
     proxy_url = settings[json_config]['proxy_url']

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -9,7 +9,7 @@
 #      @event['action'] - Property to figure out the event type i.e. whether it is create or resolve.
 #      @event['check'] - Map of attributes from the check config which is calling this handler
 #      @event['client'] - Map of attributes from the client config for the clients from which this event is generated.
-#   option: json_config - By default, assumes the hipchat config parameters are in the “hipchat” top-level json key.
+#   option: json_config - By default, assumes the hipchat config parameters are in the "hipchat" top-level json key.
 #                         This command line option allows to specify a custom json key.
 #
 # Output:
@@ -17,7 +17,7 @@
 #    Yellow coloured notification used to notify warning if a create event is seen with a status of 1
 #    Red coloured notification used to notify critical if a create event is seen with a status other than 1
 #
-# Note: The handler config is fetched and merged from all json config files. The “hipchat” json key is used by default which can
+# Note: The handler config is fetched and merged from all json config files. The "hipchat" json key is used by default which can
 #       be overridden with the "json_config" command line option. The hipchat room could also be configured on a per client basis
 #       by defining the "hipchat_room" attribute in the client config file. This will override the default hipchat room where the
 #       alerts are being routed to for that particular client.
@@ -31,7 +31,7 @@ class HipChatNotif < Sensu::Handler
          description: 'JSON config key name',
          short: '-j JsonKeyName',
          long: '--json_config JsonKeyName',
-         required: false
+         required: false,
          default: 'hipchat'
 
   def event_name


### PR DESCRIPTION
I've found the current docs for `--json_config` confusing (#3)
I think this change in `--help` message, docs and default value handling may help here.
