### PR TITLE
Add config option to extend message with evaluated ruby code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- added config option to extend message with evaluated ruby code
 
 ## [0.0.4] - 2016-08-10
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
     "apikey": "1234abcdefg1234abcdefg",
     "apiversion": "v1",
     "room": "Ops",
-    "from": "Sensu"
+    "from": "Sensu",
+    "add_msg": "\"<br>command: #{@event['check']['command']}<br>occurrences: #{@event['occurrences']}\""
   }
 }
 ```

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -67,7 +67,7 @@ class HipChatNotif < Sensu::Handler
 
     if add_msg
       begin
-        message << eval(add_msg)
+        message << eval(add_msg) # rubocop:disable Lint/Eval
       rescue
         puts "Can't evaluate: add_msg = #{add_msg}"
       end

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -46,6 +46,7 @@ class HipChatNotif < Sensu::Handler
     hipchatmsg = HipChat::Client.new(settings[json_config]['apikey'], api_version: apiversion, http_proxy: proxy_url, server_url: server_url)
     room = @event['client']['hipchat_room'] || @event['check']['hipchat_room'] || settings[json_config]['room']
     from = settings[json_config]['from'] || 'Sensu'
+    add_msg = settings[json_config]['add_msg']
 
     message = @event['check']['notification'] || @event['check']['output']
 
@@ -61,6 +62,14 @@ class HipChatNotif < Sensu::Handler
                    end
       rescue
         message << "  Playbook:  #{@event['check']['playbook']}"
+      end
+    end
+
+    if add_msg
+      begin
+        message << eval(add_msg)
+      rescue
+        puts "Can't evaluate: add_msg = #{add_msg}"
       end
     end
 


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [ ] RuboCop passes
- [ ] Existing tests pass 
#### Purpose

I need a method to extended hipchat message with arbitrary expression defined in config file.
Here's an example config that I use to add uchiwa links to hipchat messages:

```
  "hipchat": {
    "add_msg": "\"  [<a href='#{@event['check']['uchiwa']}'>Uchiwa</a>]\""
  }
```
#### Known Compatablity Issues

This change causes a RuboCop offence:

```
bin/handler-hipchat.rb:70:20: W: The use of eval is a serious security risk.
        message << eval(add_msg)
                   ^^^^
```

I don't know yet how to fix this.
