### PR TITLE
Configure message format in ERB template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+Lint/ImplicitStringConcatenation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- added option to configure message format in ERB template
 
 ## [0.0.4] - 2016-08-10
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
     "apikey": "1234abcdefg1234abcdefg",
     "apiversion": "v1",
     "room": "Ops",
-    "from": "Sensu"
+    "from": "Sensu",
+    "message_template": "optional message template erb file path - /some/path/to/template.erb"
   }
 }
 ```
@@ -28,3 +29,19 @@
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
+
+### message_template example
+
+```
+<%=
+[
+  @event["action"].eql?("resolve") ? "RESOLVED" : "ALERT",
+  " - [#{event_name}]<br>",
+  "command: #{@event['check']['command']}<br>",
+  "occurrences: #{@event['occurrences']}<br>",
+  @event["check"]["notification"] || @event["check"]["output"],
+  "<br>",
+  playbook,
+].join
+%>
+```

--- a/sensu-plugins-hipchat.gemspec
+++ b/sensu-plugins-hipchat.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'hipchat',      '1.5.1'
+  s.add_runtime_dependency 'erubis',       '2.7.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [ ] Existing tests pass 
#### Purpose

Allows to configure ERB `message_template` file and to define any arbitrary message format in it. 
(as suggested by @sstarcher in #7 )
Default format stays the same as before.

This is based on `message_template` handling in `handler-slack.rb`: 
https://github.com/sensu-plugins/sensu-plugins-slack/blob/2bddedb0d5d4269984ce586211c540bc5c36d38d/bin/handler-slack.rb#L109-L124
#### Known Compatablity Issues
