### PR TITLE
Adds 'message_format' config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - added option to configure message format in ERB template
+- added option to configure message format as either `html`(default) or `text`
 
 ## [0.0.4] - 2016-08-10
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
     "apiversion": "v1",
     "room": "Ops",
     "from": "Sensu",
-    "message_template": "optional message template erb file path - /some/path/to/template.erb"
+    "message_template": "optional message template erb file path - /some/path/to/template.erb",
+    "message_format": "html"
   }
 }
 ```

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -48,6 +48,7 @@ class HipChatNotif < Sensu::Handler
     room = @event['client']['hipchat_room'] || @event['check']['hipchat_room'] || settings[json_config]['room']
     from = settings[json_config]['from'] || 'Sensu'
     message_template = settings[json_config]['message_template']
+    message_format = settings[json_config]['message_format'] || 'html'
 
     # If the playbook attribute exists and is a URL, "[<a href='url'>playbook</a>]" will be output.
     # To control the link name, set the playbook value to the HTML output you would like.
@@ -85,9 +86,9 @@ class HipChatNotif < Sensu::Handler
     begin
       timeout(3) do
         if @event['action'].eql?('resolve')
-          hipchatmsg[room].send(from, message, color: 'green')
+          hipchatmsg[room].send(from, message, color: 'green', message_format: message_format)
         else
-          hipchatmsg[room].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true)
+          hipchatmsg[room].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true, message_format: message_format)
         end
       end
     rescue Timeout::Error


### PR DESCRIPTION
- defaults to 'html' to maintain backwards compatibility

## Pull Request Checklist

no

#### General

- [*] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [*] Update README with any necessary configuration snippets

- [?] Binstubs are created if needed

- [?] RuboCop passes

- [?] Existing tests pass 

#### Purpose

This PR allows users to specify if they want to send their messages to the HipChat API as either `html`(default) or `text`.

The `text` option tells HipChat to auto-format the message, and support "mentions". The mention option is particularly useful as it triggers a notification in hipchat clients.

#### Known Compatablity Issues

None that I am aware of

#### Full disclosure

I'm not a Ruby guy, and this is the first time I've used the language. Hope I didn't miss anything obvious :) The patch is simple, and works for us. I am not familiar with Binstubs, Robocup or Ruby-testing, hence the 3 question marks. Sorry about that! Hope this is useful anyways.