### PR TITLE
Remove 1.9.3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 
 #### Purpose
 
-#### Known Compatability Issues
+#### Known Compatibility Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-## [1.1.0] - 2017-07-12
+### Breaking Changes
+- Minimum Ruby runtime version is now 2.0
+
+## [1.0.0] - 2017-07-12
 ### Added
 - Ruby 2.4.1 testing
 

--- a/sensu-plugins-hipchat.gemspec
+++ b/sensu-plugins-hipchat.gemspec
@@ -6,7 +6,6 @@ require_relative 'lib/sensu-plugins-hipchat'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
-  # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for hipchat'
   s.email                  = '<sensu-users@googlegroups.com>'
@@ -23,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for hipchat'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsHipchat::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

Followup to #12.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass

#### Purpose

Drop Ruby 1.9.3 support.

#### Known Compatibility Issues

Minimum Ruby version is now 2.0.
