### PR TITLE
Fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- updated sensu-plugin gem to `~> 2.0`
+- fix runtime warnings
 
 ## [2.0.0] - 2017-07-24
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Changed
-- updated sensu-plugin gem to `~> 2.0`
-- fix runtime warnings
+### Breaking Changes
+- bumped dependency of `sensu-plugin` to 2.x you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29) (@multani)
+
+### Fixed
+- fix runtime warnings (@multani)
 
 ## [2.0.0] - 2017-07-24
 ### Breaking Changes

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -84,7 +84,7 @@ class HipChatNotif < Sensu::Handler
     message = eruby.result(binding)
 
     begin
-      timeout(3) do
+      Timeout.timeout(3) do
         if @event['action'].eql?('resolve')
           hipchatmsg[room].send(from, message, color: 'green', message_format: message_format)
         else

--- a/sensu-plugins-hipchat.gemspec
+++ b/sensu-plugins-hipchat.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsHipchat::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'hipchat',      '1.5.1'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.0'
   s.add_runtime_dependency 'erubis',       '2.7.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

Fixes #9 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Fix some runtime warnings. Test artifact:

Before:
```
$ cat <<EOF | bundle exec bin/handler-hipchat.rb
{
  "client": {
    "name": "client"
  },
  "check": {
    "status": 1,
    "name": "name",
    "source": "source",
    "output": "Hello, warning"
  }
}
EOF

warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
connection refused attempting to query the sensu api for a stash
connection refused attempting to query the sensu api for a stash
connection refused attempting to query the sensu api for a stash
warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
bin/handler-hipchat.rb:87:in `handle': Object#timeout is deprecated, use Timeout.timeout instead.
$
```

After:
```
$ cat <<EOF | bundle exec bin/handler-hipchat.rb
{
  "client": {
    "name": "client"
  },
  "check": {
    "status": 1,
    "name": "name",
    "source": "source",
    "output": "Hello, warning"
  }
}
EOF
$
```
(and yes, the message still arrives in Hipchat :p )

#### Known Compatibility Issues

The sensu-plugin gem has been updated, but I don't think what this handler does with it should break anything.