### PR TITLE
hipchat: remove trailing spaces, which appears on "text" message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Remove trailing whitespace in the default template
 
 ## [2.0.0] - 2017-07-24
 ### Breaking Changes

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -77,8 +77,7 @@ class HipChatNotif < Sensu::Handler
         playbook,
         "."
       ].join
-      %>
-      '''
+      %>'''
     end
     eruby = Erubis::Eruby.new(template)
     message = eruby.result(binding)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

The default message sent on Hipchat contained trailing whitespaces. By default, using the "HTML" message format, they don't really appear, but switching to the "text" message format reveals some extraneous spaces at the end of each messages. See the screenshot below, were the 2 first messages were produced using the previous code, whereas the last 2 messages were produces using the code from this PR.

![screenshot from 2017-12-05 14-30-02](https://user-images.githubusercontent.com/65311/33611189-c8a83af0-d9cd-11e7-9434-d63ad1da172b.png)


#### Known Compatibility Issues

I considered stripping the final output from the template which I think would have been better, but in case someone is using a custom template and *really* wants to have extra spaces at the end of its message, then calling ``.strip`` would prevent that 🤷‍