### PR TITLE
Support multiple rooms to notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- support list of hipchat rooms, so notifications are sent to multiple rooms
 
 ## [3.0.0] - 2017-12-07
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ cat <<EOF | bundle exec bin/handler-hipchat.rb
     "status": 1,
     "name": "name",
     "source": "source",
-    "output": "Hello, warning"
+    "output": "Hello, warning",
+    "hipchat_room": ["general","important"]
   }
 }
 EOF

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -84,10 +84,17 @@ class HipChatNotif < Sensu::Handler
 
     begin
       Timeout.timeout(3) do
+        unless room.is_a?(Array)
+          room = [room]
+        end
         if @event['action'].eql?('resolve')
-          hipchatmsg[room].send(from, message, color: 'green', message_format: message_format)
+          room.each do |x|
+            hipchatmsg[x].send(from, message, color: 'green', message_format: message_format)
+          end
         else
-          hipchatmsg[room].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true, message_format: message_format)
+          room.each do |x|
+            hipchatmsg[x].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true, message_format: message_format)
+          end
         end
       end
     rescue Timeout::Error

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -98,7 +98,7 @@ class HipChatNotif < Sensu::Handler
         end
       end
     rescue Timeout::Error
-      puts "hipchat -- timed out while attempting to message #{rooms.join(", ")}"
+      puts "hipchat -- timed out while attempting to message #{rooms.join(', ')}"
     end
   end
 end

--- a/bin/handler-hipchat.rb
+++ b/bin/handler-hipchat.rb
@@ -45,7 +45,7 @@ class HipChatNotif < Sensu::Handler
     apiversion = settings[json_config]['apiversion'] || 'v1'
     proxy_url = settings[json_config]['proxy_url']
     hipchatmsg = HipChat::Client.new(settings[json_config]['apikey'], api_version: apiversion, http_proxy: proxy_url, server_url: server_url)
-    room = @event['client']['hipchat_room'] || @event['check']['hipchat_room'] || settings[json_config]['room']
+    rooms = @event['client']['hipchat_room'] || @event['check']['hipchat_room'] || settings[json_config]['room']
     from = settings[json_config]['from'] || 'Sensu'
     message_template = settings[json_config]['message_template']
     message_format = settings[json_config]['message_format'] || 'html'
@@ -84,21 +84,21 @@ class HipChatNotif < Sensu::Handler
 
     begin
       Timeout.timeout(3) do
-        unless room.is_a?(Array)
-          room = [room]
+        unless rooms.is_a?(Array)
+          rooms = [rooms]
         end
         if @event['action'].eql?('resolve')
-          room.each do |x|
-            hipchatmsg[x].send(from, message, color: 'green', message_format: message_format)
+          rooms.each do |room|
+            hipchatmsg[room].send(from, message, color: 'green', message_format: message_format)
           end
         else
-          room.each do |x|
-            hipchatmsg[x].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true, message_format: message_format)
+          rooms.each do |room|
+            hipchatmsg[room].send(from, message, color: @event['check']['status'] == 1 ? 'yellow' : 'red', notify: true, message_format: message_format)
           end
         end
       end
     rescue Timeout::Error
-      puts "hipchat -- timed out while attempting to message #{room}"
+      puts "hipchat -- timed out while attempting to message #{rooms.join(", ")}"
     end
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Nope

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [X] Existing tests pass

#### Purpose

Support to send notifications to multiple rooms. This is useful for checks which have shared ownership or responsibility.

#### Known Compatibility Issues

None, single rooms still works and are casted to list.